### PR TITLE
Make Evaluation Exact

### DIFF
--- a/tests/integration/test_end_to_end.py
+++ b/tests/integration/test_end_to_end.py
@@ -113,5 +113,5 @@ def test_training_regression(spark_context, mode, parameter_server_mode, num_wor
     #  and when the mean of those means is computed, we would get 2.
     # This isn't an issue with classification models because it only requires the argmax be correct in the result array
     # TODO quantify the maximum difference and make that the tolerance?
-    assert isclose(evals[0], spark_model.master_network.evaluate(x_test, y_test)[0], abs_tol=5.0)
-    assert isclose(evals[1], spark_model.master_network.evaluate(x_test, y_test)[1], abs_tol=5.0)
+    assert isclose(evals[0], spark_model.master_network.evaluate(x_test, y_test)[0], abs_tol=0.01)
+    assert isclose(evals[1], spark_model.master_network.evaluate(x_test, y_test)[1], abs_tol=0.01)


### PR DESCRIPTION
Currently,  the implementation of distributed `evaluate` is an approximation in the case of regression, because differing partition sizes can affect the computation of the mean. For example:

```
x = [1, 2, 3, 4]
```

`x` has a mean of 2.5 (10/4), but if x were partitioned:

```
x_p1 = [1], x_p2 = [2, 3, 4]
```
The mean of the first partition would be 1, the mean of the second partition would be 3 (9 / 3), and when we take the mean of those two means, we would get 2.

To mitigate this, we can apply a mapping function where we scale the partition mean by the sample size, and also maintain the sample size. With `n` partitions:
```
x_p1 -> (s_p1 * u_p1, s_p1), x_p2 -> (s_p2 * u_p2, s_p2), ..., x_pn -> (s_pn * u_pn, s_pn)
```

Where `s_pn` is the number of samples in the `nth` partition, `u_pn` is the mean of the `nth` partition

In the example case
```
u_p1 = 1, s_p1 = 1
u_p2 = 9, s_p2 = 3
x_p1 -> (1   * 1,  1) , x_p2 -> (3 * 9, 3)
```

Then reduce by summing the first and second values:

```
[(s_p1 * u_p1, s_p1), (s_p2 * u_p2, s_p2)] -> (s_p1 * u_p1 + s_p2 * u_p2, s_p1 + s_p2)
```


The final tuple of the reduce function are then the total sum across partitions `S_p`, and the total samples `n`. We can then divide the two values to compute the true mean `u`:

```
u = S_p / n
```

In the example case:

```
(1 * 1 + 3 * 3, 1 + 3) -> (10, 4)
10 / 4 = 2.5
```


**Note**: the scaling of the mean by the sample size seems redundant since you theoretically can just use the sum and avoid that calculation, but `model.evaluate` in the Keras API computes the average loss/metric value.

This fix ensures the single machine model evaluation results match the distributed evaluation results.

