### PR TITLE
Enable multiple metrics

### DIFF
--- a/tests/integration/test_end_to_end.py
+++ b/tests/integration/test_end_to_end.py
@@ -85,7 +85,7 @@ def test_training_regression(spark_context, mode, parameter_server_mode, num_wor
     batch_size = 64
     epochs = 10
     sgd = SGD(lr=0.0000001)
-    regression_model.compile(sgd, 'mse', ['mae'])
+    regression_model.compile(sgd, 'mse', ['mae', 'mean_absolute_percentage_error'])
     spark_model = SparkModel(regression_model, frequency='epoch', mode=mode, num_workers=num_workers,
                              parameter_server_mode=parameter_server_mode, port=4000 + random.randint(0, 800))
 
@@ -106,12 +106,7 @@ def test_training_regression(spark_context, mode, parameter_server_mode, num_wor
     assert all(np.isclose(x, y, 0.01) for x, y in zip(predictions, spark_model.master_network.predict(x_test)))
 
     # assert we get the same evaluation results when calling evaluate on keras model directly
-    # NOTE: the tolerance is fairly large because when comparing the distributed mean evaluation vs. the
-    # keras model, there is a slight difference due to rounding and mean computations when the partitions aren't equal
-    #
-    # e.g; [1, 2, 3, 4] => mean is 2.5, but if partitioned to [1], [2, 3, 4], the individual means would be 1 and 9 / 3 (3)
-    #  and when the mean of those means is computed, we would get 2.
-    # This isn't an issue with classification models because it only requires the argmax be correct in the result array
-    # TODO quantify the maximum difference and make that the tolerance?
     assert isclose(evals[0], spark_model.master_network.evaluate(x_test, y_test)[0], abs_tol=0.01)
     assert isclose(evals[1], spark_model.master_network.evaluate(x_test, y_test)[1], abs_tol=0.01)
+    assert isclose(evals[2], spark_model.master_network.evaluate(x_test, y_test)[2], abs_tol=0.01)
+


### PR DESCRIPTION
With the update to how we compute `evaluation` in the [previous PR](https://github.com/danielenricocahall/elephas/pull/1), I realized we didn't support more than one metric (in the old implementation and in the new). In this PR, I address that issue by making the new mapper and reducer functions dynamic. Also, deleted outdated comment.

