### PR TITLE
Hadoop cluster option

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Table of content:
   * [Basic Spark integration](#basic-spark-integration)
   * [Spark MLlib integration](#spark-mllib-integration)
   * [Spark ML integration](#spark-ml-integration)
+  * [Hadoop integration](#hadoop-integration)
   * [Distributed hyper-parameter optimization](#distributed-hyper-parameter-optimization)
   * [Distributed training of ensemble models](#distributed-training-of-ensemble-models)
   * [Discussion](#discussion)
@@ -191,6 +192,22 @@ model.add(CustomLayer(...))
 
 estimator = ElephasEstimator(model, epochs=epochs, batch_size=batch_size)
 estimator.set_custom_objects({'custom_activation': custom_activation, 'CustomLayer': CustomLayer})
+```
+
+## Hadoop Integration
+
+In addition to saving locally, models may be saved directly into a network-accessible Hadoop cluster.
+
+```python
+spark_model.save('/absolute/file/path/model.h5', to_hadoop=True)
+```
+
+Models saved on a network-accessible Hadoop cluster may be loaded as follows.
+
+```python
+from elephas.spark_model import load_spark_model
+
+spark_model = load_spark_model('/absolute/file/path/model.h5', from_hadoop=True)
 ```
 
 ## Distributed hyper-parameter optimization

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 from setuptools import find_packages
 
 setup(name='elephas',
-      version='3.3.0',
+      version='3.4.0',
       description='Deep learning on Spark with Keras',
       url='http://github.com/danielenricocahall/elephas',
       download_url='https://github.com/danielenricocahall/elephas/tarball/3.3.0',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 from setuptools import find_packages
 
 setup(name='elephas',
-      version='3.4.0',
+      version='3.3.0',
       description='Deep learning on Spark with Keras',
       url='http://github.com/danielenricocahall/elephas',
       download_url='https://github.com/danielenricocahall/elephas/tarball/3.3.0',


### PR DESCRIPTION
Changelog:
- Added assertions statements to validate the file_name inputs are strings with either ".h5" or ".keras" suffixes.
- Enabled saving Spark models into a network-accessible Hadoop cluster.
- Enabled loading Spark models from a network-accessible Hadoop cluster.

Not implemented but should be considered for future changes:
- Add a try-except clause to attempt using "hdfs dfs" CLI options rather than "hadoop fs" when those CLI options do not work.
- Make `ElephasEstimator` and `ElephasTransformer` classes from `elephas.ml_model` subclasses of `pyspark.ml.util.MLWritable` so that they may be able to be saved as part of pipelines fitted with those classes within them.