### PR TITLE
Support for Python 3.11

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/examples/mllib_mlp.py
+++ b/examples/mllib_mlp.py
@@ -1,7 +1,7 @@
 from tensorflow.keras.datasets import mnist
 from tensorflow.keras.models import Sequential
 from tensorflow.keras.layers import Dense, Dropout, Activation
-from tensorflow.keras.optimizers import RMSprop
+from tensorflow.keras.optimizers.legacy import RMSprop
 from tensorflow.keras.utils import to_categorical
 
 from elephas.spark_model import SparkMLlibModel

--- a/examples/mnist_mlp_spark.py
+++ b/examples/mnist_mlp_spark.py
@@ -1,7 +1,7 @@
 from tensorflow.keras.datasets import mnist
 from tensorflow.keras.models import Sequential
 from tensorflow.keras.layers import Dense, Dropout, Activation
-from tensorflow.keras.optimizers import SGD
+from tensorflow.keras.optimizers.legacy import SGD
 from tensorflow.keras.utils import to_categorical
 
 from elephas.spark_model import SparkModel

--- a/examples/mnist_mlp_spark_asynchronous.py
+++ b/examples/mnist_mlp_spark_asynchronous.py
@@ -1,7 +1,7 @@
 from tensorflow.keras.datasets import mnist
 from tensorflow.keras.models import Sequential
 from tensorflow.keras.layers import Dense, Dropout, Activation
-from tensorflow.keras.optimizers import SGD
+from tensorflow.keras.optimizers.legacy import SGD
 from tensorflow.keras.utils import to_categorical
 
 from elephas.spark_model import SparkModel

--- a/examples/mnist_mlp_spark_synchronous.py
+++ b/examples/mnist_mlp_spark_synchronous.py
@@ -1,7 +1,7 @@
 from tensorflow.keras.datasets import mnist
 from tensorflow.keras.models import Sequential
 from tensorflow.keras.layers import Dense, Dropout, Activation
-from tensorflow.keras.optimizers import SGD
+from tensorflow.keras.optimizers.legacy import SGD
 from tensorflow.keras.utils import to_categorical
 
 from elephas.spark_model import SparkModel

--- a/poetry.lock
+++ b/poetry.lock
@@ -186,14 +186,14 @@ requests = ["requests (>=2.20.0,<3.0.0dev)"]
 
 [[package]]
 name = "google-auth-oauthlib"
-version = "0.4.6"
+version = "1.0.0"
 description = "Google Authentication Library"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-google-auth = ">=1.0.0"
+google-auth = ">=2.15.0"
 requests-oauthlib = ">=0.7.0"
 
 [package.extras]
@@ -273,6 +273,34 @@ optional = false
 python-versions = ">=3.7"
 
 [[package]]
+name = "jax"
+version = "0.4.13"
+description = "Differentiate, compile, and transform Numpy code."
+category = "main"
+optional = false
+python-versions = ">=3.8"
+
+[package.dependencies]
+importlib_metadata = {version = ">=4.6", markers = "python_version < \"3.10\""}
+ml_dtypes = ">=0.1.0"
+numpy = ">=1.21"
+opt_einsum = "*"
+scipy = ">=1.7"
+
+[package.extras]
+australis = ["protobuf (>=3.13,<4)"]
+ci = ["jaxlib (==0.4.12)"]
+cpu = ["jaxlib (==0.4.13)"]
+cuda = ["jaxlib (==0.4.13+cuda11.cudnn86)"]
+cuda11_cudnn86 = ["jaxlib (==0.4.13+cuda11.cudnn86)"]
+cuda11_local = ["jaxlib (==0.4.13+cuda11.cudnn86)"]
+cuda11_pip = ["jaxlib (==0.4.13+cuda11.cudnn86)", "nvidia-cublas-cu11 (>=11.11)", "nvidia-cuda-cupti-cu11 (>=11.8)", "nvidia-cuda-nvcc-cu11 (>=11.8)", "nvidia-cuda-runtime-cu11 (>=11.8)", "nvidia-cudnn-cu11 (>=8.8)", "nvidia-cufft-cu11 (>=10.9)", "nvidia-cusolver-cu11 (>=11.4)", "nvidia-cusparse-cu11 (>=11.7)"]
+cuda12_local = ["jaxlib (==0.4.13+cuda12.cudnn89)"]
+cuda12_pip = ["jaxlib (==0.4.13+cuda12.cudnn89)", "nvidia-cublas-cu12", "nvidia-cuda-cupti-cu12", "nvidia-cuda-nvcc-cu12", "nvidia-cuda-runtime-cu12", "nvidia-cudnn-cu12 (>=8.9)", "nvidia-cufft-cu12", "nvidia-cusolver-cu12", "nvidia-cusparse-cu12"]
+minimum-jaxlib = ["jaxlib (==0.4.11)"]
+tpu = ["jaxlib (==0.4.13)", "libtpu-nightly (==0.1.dev20230622)"]
+
+[[package]]
 name = "jinja2"
 version = "3.1.2"
 description = "A very fast and expressive template engine."
@@ -288,28 +316,11 @@ i18n = ["Babel (>=2.7)"]
 
 [[package]]
 name = "keras"
-version = "2.10.0"
+version = "2.12.0"
 description = "Deep learning for humans."
 category = "main"
 optional = false
-python-versions = "*"
-
-[[package]]
-name = "keras-preprocessing"
-version = "1.1.2"
-description = "Easy data preprocessing and data augmentation for deep learning models"
-category = "main"
-optional = false
-python-versions = "*"
-
-[package.dependencies]
-numpy = ">=1.9.1"
-six = ">=1.9.0"
-
-[package.extras]
-image = ["scipy (>=0.14)", "Pillow (>=5.2.0)"]
-pep8 = ["flake8"]
-tests = ["pandas", "pillow", "tensorflow", "keras", "pytest", "pytest-xdist", "pytest-cov"]
+python-versions = ">=3.8"
 
 [[package]]
 name = "libclang"
@@ -340,6 +351,24 @@ description = "Safely add untrusted strings to HTML/XML markup."
 category = "main"
 optional = false
 python-versions = ">=3.7"
+
+[[package]]
+name = "ml-dtypes"
+version = "0.2.0"
+description = ""
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+numpy = [
+    {version = ">1.20", markers = "python_version <= \"3.9\""},
+    {version = ">=1.23.3", markers = "python_version > \"3.10\""},
+    {version = ">=1.21.2", markers = "python_version > \"3.9\""},
+]
+
+[package.extras]
+dev = ["absl-py", "pytest", "pytest-xdist", "pylint (>=2.6.0)", "pyink"]
 
 [[package]]
 name = "mock"
@@ -420,11 +449,11 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "protobuf"
-version = "3.19.6"
-description = "Protocol Buffers"
+version = "4.24.4"
+description = ""
 category = "main"
 optional = false
-python-versions = ">=3.5"
+python-versions = ">=3.7"
 
 [[package]]
 name = "py4j"
@@ -587,6 +616,22 @@ python-versions = ">=3.6,<4"
 pyasn1 = ">=0.1.3"
 
 [[package]]
+name = "scipy"
+version = "1.10.1"
+description = "Fundamental algorithms for scientific computing in Python"
+category = "main"
+optional = false
+python-versions = "<3.12,>=3.8"
+
+[package.dependencies]
+numpy = ">=1.19.5,<1.27.0"
+
+[package.extras]
+test = ["pytest", "pytest-cov", "pytest-timeout", "pytest-xdist", "asv", "mpmath", "gmpy2", "threadpoolctl", "scikit-umfpack", "pooch"]
+doc = ["sphinx (!=4.1.0)", "pydata-sphinx-theme (==0.9.0)", "sphinx-design (>=0.2.0)", "matplotlib (>2)", "numpydoc"]
+dev = ["mypy", "typing-extensions", "pycodestyle", "flake8", "rich-click", "click", "doit (>=0.36.0)", "pydevtool"]
+
+[[package]]
 name = "six"
 version = "1.16.0"
 description = "Python 2 and 3 compatibility utilities"
@@ -596,48 +641,39 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "tensorboard"
-version = "2.10.1"
+version = "2.12.3"
 description = "TensorBoard lets you watch Tensors Flow"
 category = "main"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.8"
 
 [package.dependencies]
 absl-py = ">=0.4"
 google-auth = ">=1.6.3,<3"
-google-auth-oauthlib = ">=0.4.1,<0.5"
-grpcio = ">=1.24.3"
+google-auth-oauthlib = ">=0.5,<1.1"
+grpcio = ">=1.48.2"
 markdown = ">=2.6.8"
 numpy = ">=1.12.0"
-protobuf = ">=3.9.2,<3.20"
+protobuf = ">=3.19.6"
 requests = ">=2.21.0,<3"
-tensorboard-data-server = ">=0.6.0,<0.7.0"
-tensorboard-plugin-wit = ">=1.6.0"
+tensorboard-data-server = ">=0.7.0,<0.8.0"
 werkzeug = ">=1.0.1"
 
 [[package]]
 name = "tensorboard-data-server"
-version = "0.6.1"
+version = "0.7.2"
 description = "Fast data loading for TensorBoard"
 category = "main"
 optional = false
-python-versions = ">=3.6"
-
-[[package]]
-name = "tensorboard-plugin-wit"
-version = "1.8.1"
-description = "What-If Tool TensorBoard plugin."
-category = "main"
-optional = false
-python-versions = "*"
+python-versions = ">=3.7"
 
 [[package]]
 name = "tensorflow"
-version = "2.10.0"
+version = "2.12.0"
 description = "TensorFlow is an open source machine learning framework for everyone."
 category = "main"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 
 [package.dependencies]
 absl-py = ">=1.0.0"
@@ -647,24 +683,24 @@ gast = ">=0.2.1,<=0.4.0"
 google-pasta = ">=0.1.1"
 grpcio = ">=1.24.3,<2.0"
 h5py = ">=2.9.0"
-keras = ">=2.10.0,<2.11"
-keras-preprocessing = ">=1.1.1"
+jax = ">=0.3.15"
+keras = ">=2.12.0,<2.13"
 libclang = ">=13.0.0"
-numpy = ">=1.20"
+numpy = ">=1.22,<1.24"
 opt-einsum = ">=2.3.2"
 packaging = "*"
-protobuf = ">=3.9.2,<3.20"
+protobuf = ">=3.20.3,<4.21.0 || >4.21.0,<4.21.1 || >4.21.1,<4.21.2 || >4.21.2,<4.21.3 || >4.21.3,<4.21.4 || >4.21.4,<4.21.5 || >4.21.5,<5.0.0dev"
 six = ">=1.12.0"
-tensorboard = ">=2.10,<2.11"
-tensorflow-estimator = ">=2.10.0,<2.11"
-tensorflow-io-gcs-filesystem = ">=0.23.1"
+tensorboard = ">=2.12,<2.13"
+tensorflow-estimator = ">=2.12.0,<2.13"
+tensorflow-io-gcs-filesystem = {version = ">=0.23.1", markers = "platform_machine != \"arm64\" or platform_system != \"Darwin\""}
 termcolor = ">=1.1.0"
 typing-extensions = ">=3.6.6"
-wrapt = ">=1.11.0"
+wrapt = ">=1.11.0,<1.15"
 
 [[package]]
 name = "tensorflow-estimator"
-version = "2.10.0"
+version = "2.12.0"
 description = "TensorFlow Estimator."
 category = "main"
 optional = false
@@ -741,7 +777,7 @@ watchdog = ["watchdog"]
 
 [[package]]
 name = "wrapt"
-version = "1.15.0"
+version = "1.14.1"
 description = "Module for decorators, wrappers and monkey patching."
 category = "main"
 optional = false
@@ -762,7 +798,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "flake8 (<5)", "pytest-co
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8,<3.12"
-content-hash = "310a196ed6b62404370acdbfcae16c1333f574764c20bcd0acc3aee0e3ba743b"
+content-hash = "c906ccdf13889b41833c6785a6d00828cc1ae6744c1b089588812533841c413f"
 
 [metadata.files]
 absl-py = []
@@ -791,10 +827,7 @@ gast = [
     {file = "gast-0.4.0.tar.gz", hash = "sha256:40feb7b8b8434785585ab224d1568b857edb18297e5a3047f1ba012bc83b42c1"},
 ]
 google-auth = []
-google-auth-oauthlib = [
-    {file = "google-auth-oauthlib-0.4.6.tar.gz", hash = "sha256:a90a072f6993f2c327067bf65270046384cda5a8ecb20b94ea9a687f1f233a7a"},
-    {file = "google_auth_oauthlib-0.4.6-py2.py3-none-any.whl", hash = "sha256:3f2a6e802eebbb6fb736a370fbf3b055edcb6b52878bf2f26330b5e041316c73"},
-]
+google-auth-oauthlib = []
 google-pasta = [
     {file = "google-pasta-0.2.0.tar.gz", hash = "sha256:c9f2c8dfc8f96d0d5808299920721be30c9eec37f2389f28904f454565c8a16e"},
     {file = "google_pasta-0.2.0-py2-none-any.whl", hash = "sha256:4612951da876b1a10fe3960d7226f0c7682cf901e16ac06e473b267a5afa8954"},
@@ -806,15 +839,13 @@ idna = []
 importlib-metadata = []
 iniconfig = []
 itsdangerous = []
+jax = []
 jinja2 = []
 keras = []
-keras-preprocessing = [
-    {file = "Keras_Preprocessing-1.1.2-py2.py3-none-any.whl", hash = "sha256:7b82029b130ff61cc99b55f3bd27427df4838576838c5b2f65940e4fcec99a7b"},
-    {file = "Keras_Preprocessing-1.1.2.tar.gz", hash = "sha256:add82567c50c8bc648c14195bf544a5ce7c1f76761536956c3d2978970179ef3"},
-]
 libclang = []
 markdown = []
 markupsafe = []
+ml-dtypes = []
 mock = []
 numpy = []
 oauthlib = []
@@ -872,19 +903,13 @@ requests-oauthlib = [
     {file = "requests_oauthlib-1.3.1-py2.py3-none-any.whl", hash = "sha256:2577c501a2fb8d05a304c09d090d6e47c306fef15809d102b327cf8364bddab5"},
 ]
 rsa = []
+scipy = []
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
     {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
 ]
 tensorboard = []
-tensorboard-data-server = [
-    {file = "tensorboard_data_server-0.6.1-py3-none-any.whl", hash = "sha256:809fe9887682d35c1f7d1f54f0f40f98bb1f771b14265b453ca051e2ce58fca7"},
-    {file = "tensorboard_data_server-0.6.1-py3-none-macosx_10_9_x86_64.whl", hash = "sha256:fa8cef9be4fcae2f2363c88176638baf2da19c5ec90addb49b1cde05c95c88ee"},
-    {file = "tensorboard_data_server-0.6.1-py3-none-manylinux2010_x86_64.whl", hash = "sha256:d8237580755e58eff68d1f3abefb5b1e39ae5c8b127cc40920f9c4fb33f4b98a"},
-]
-tensorboard-plugin-wit = [
-    {file = "tensorboard_plugin_wit-1.8.1-py3-none-any.whl", hash = "sha256:ff26bdd583d155aa951ee3b152b3d0cffae8005dc697f72b44a8e8c2a77a8cbe"},
-]
+tensorboard-data-server = []
 tensorflow = []
 tensorflow-estimator = []
 tensorflow-io-gcs-filesystem = []

--- a/poetry.lock
+++ b/poetry.lock
@@ -736,7 +736,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "flake8 (<5)", "pytest-co
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8,<3.12"
-content-hash = "1f2c0ce6f53565271820d57ce356e59d3a0a18785a845b027db8672368dd28b1"
+content-hash = "6244d68e072f7222a92101d05aff7c2ffadc73c2b3afaecd5691ad705d1f79a6"
 
 [metadata.files]
 absl-py = []

--- a/poetry.lock
+++ b/poetry.lock
@@ -78,11 +78,11 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7
 
 [[package]]
 name = "coverage"
-version = "7.2.1"
+version = "7.3.2"
 description = "Code coverage measurement for Python"
 category = "dev"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 
 [package.dependencies]
 tomli = {version = "*", optional = true, markers = "python_full_version <= \"3.11.0a6\" and extra == \"toml\""}

--- a/poetry.lock
+++ b/poetry.lock
@@ -273,34 +273,6 @@ optional = false
 python-versions = ">=3.7"
 
 [[package]]
-name = "jax"
-version = "0.4.13"
-description = "Differentiate, compile, and transform Numpy code."
-category = "main"
-optional = false
-python-versions = ">=3.8"
-
-[package.dependencies]
-importlib_metadata = {version = ">=4.6", markers = "python_version < \"3.10\""}
-ml_dtypes = ">=0.1.0"
-numpy = ">=1.21"
-opt_einsum = "*"
-scipy = ">=1.7"
-
-[package.extras]
-australis = ["protobuf (>=3.13,<4)"]
-ci = ["jaxlib (==0.4.12)"]
-cpu = ["jaxlib (==0.4.13)"]
-cuda = ["jaxlib (==0.4.13+cuda11.cudnn86)"]
-cuda11_cudnn86 = ["jaxlib (==0.4.13+cuda11.cudnn86)"]
-cuda11_local = ["jaxlib (==0.4.13+cuda11.cudnn86)"]
-cuda11_pip = ["jaxlib (==0.4.13+cuda11.cudnn86)", "nvidia-cublas-cu11 (>=11.11)", "nvidia-cuda-cupti-cu11 (>=11.8)", "nvidia-cuda-nvcc-cu11 (>=11.8)", "nvidia-cuda-runtime-cu11 (>=11.8)", "nvidia-cudnn-cu11 (>=8.8)", "nvidia-cufft-cu11 (>=10.9)", "nvidia-cusolver-cu11 (>=11.4)", "nvidia-cusparse-cu11 (>=11.7)"]
-cuda12_local = ["jaxlib (==0.4.13+cuda12.cudnn89)"]
-cuda12_pip = ["jaxlib (==0.4.13+cuda12.cudnn89)", "nvidia-cublas-cu12", "nvidia-cuda-cupti-cu12", "nvidia-cuda-nvcc-cu12", "nvidia-cuda-runtime-cu12", "nvidia-cudnn-cu12 (>=8.9)", "nvidia-cufft-cu12", "nvidia-cusolver-cu12", "nvidia-cusparse-cu12"]
-minimum-jaxlib = ["jaxlib (==0.4.11)"]
-tpu = ["jaxlib (==0.4.13)", "libtpu-nightly (==0.1.dev20230622)"]
-
-[[package]]
 name = "jinja2"
 version = "3.1.2"
 description = "A very fast and expressive template engine."
@@ -316,7 +288,7 @@ i18n = ["Babel (>=2.7)"]
 
 [[package]]
 name = "keras"
-version = "2.12.0"
+version = "2.13.1"
 description = "Deep learning for humans."
 category = "main"
 optional = false
@@ -351,24 +323,6 @@ description = "Safely add untrusted strings to HTML/XML markup."
 category = "main"
 optional = false
 python-versions = ">=3.7"
-
-[[package]]
-name = "ml-dtypes"
-version = "0.2.0"
-description = ""
-category = "main"
-optional = false
-python-versions = ">=3.7"
-
-[package.dependencies]
-numpy = [
-    {version = ">1.20", markers = "python_version <= \"3.9\""},
-    {version = ">=1.23.3", markers = "python_version > \"3.10\""},
-    {version = ">=1.21.2", markers = "python_version > \"3.9\""},
-]
-
-[package.extras]
-dev = ["absl-py", "pytest", "pytest-xdist", "pylint (>=2.6.0)", "pyink"]
 
 [[package]]
 name = "mock"
@@ -457,7 +411,7 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "py4j"
-version = "0.10.9.5"
+version = "0.10.9.7"
 description = "Enables Python programs to dynamically access arbitrary Java objects"
 category = "main"
 optional = false
@@ -484,20 +438,21 @@ pyasn1 = ">=0.4.6,<0.5.0"
 
 [[package]]
 name = "pyspark"
-version = "3.3.0"
+version = "3.5.0"
 description = "Apache Spark Python API"
 category = "main"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 
 [package.dependencies]
-py4j = "0.10.9.5"
+py4j = "0.10.9.7"
 
 [package.extras]
+connect = ["googleapis-common-protos (>=1.56.4)", "grpcio-status (>=1.56.0)", "grpcio (>=1.56.0)", "numpy (>=1.15)", "pandas (>=1.0.5)", "pyarrow (>=4.0.0)"]
 ml = ["numpy (>=1.15)"]
 mllib = ["numpy (>=1.15)"]
-pandas_on_spark = ["numpy (>=1.15)", "pandas (>=1.0.5)", "pyarrow (>=1.0.0)"]
-sql = ["pandas (>=1.0.5)", "pyarrow (>=1.0.0)"]
+pandas_on_spark = ["numpy (>=1.15)", "pandas (>=1.0.5)", "pyarrow (>=4.0.0)"]
+sql = ["numpy (>=1.15)", "pandas (>=1.0.5)", "pyarrow (>=4.0.0)"]
 
 [[package]]
 name = "pytest"
@@ -616,22 +571,6 @@ python-versions = ">=3.6,<4"
 pyasn1 = ">=0.1.3"
 
 [[package]]
-name = "scipy"
-version = "1.10.1"
-description = "Fundamental algorithms for scientific computing in Python"
-category = "main"
-optional = false
-python-versions = "<3.12,>=3.8"
-
-[package.dependencies]
-numpy = ">=1.19.5,<1.27.0"
-
-[package.extras]
-test = ["pytest", "pytest-cov", "pytest-timeout", "pytest-xdist", "asv", "mpmath", "gmpy2", "threadpoolctl", "scikit-umfpack", "pooch"]
-doc = ["sphinx (!=4.1.0)", "pydata-sphinx-theme (==0.9.0)", "sphinx-design (>=0.2.0)", "matplotlib (>2)", "numpydoc"]
-dev = ["mypy", "typing-extensions", "pycodestyle", "flake8", "rich-click", "click", "doit (>=0.36.0)", "pydevtool"]
-
-[[package]]
 name = "six"
 version = "1.16.0"
 description = "Python 2 and 3 compatibility utilities"
@@ -641,7 +580,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "tensorboard"
-version = "2.12.3"
+version = "2.13.0"
 description = "TensorBoard lets you watch Tensors Flow"
 category = "main"
 optional = false
@@ -669,7 +608,7 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "tensorflow"
-version = "2.12.0"
+version = "2.13.1"
 description = "TensorFlow is an open source machine learning framework for everyone."
 category = "main"
 optional = false
@@ -678,29 +617,28 @@ python-versions = ">=3.8"
 [package.dependencies]
 absl-py = ">=1.0.0"
 astunparse = ">=1.6.0"
-flatbuffers = ">=2.0"
+flatbuffers = ">=23.1.21"
 gast = ">=0.2.1,<=0.4.0"
 google-pasta = ">=0.1.1"
 grpcio = ">=1.24.3,<2.0"
 h5py = ">=2.9.0"
-jax = ">=0.3.15"
-keras = ">=2.12.0,<2.13"
+keras = ">=2.13.1,<2.14"
 libclang = ">=13.0.0"
-numpy = ">=1.22,<1.24"
+numpy = ">=1.22,<=1.24.3"
 opt-einsum = ">=2.3.2"
 packaging = "*"
 protobuf = ">=3.20.3,<4.21.0 || >4.21.0,<4.21.1 || >4.21.1,<4.21.2 || >4.21.2,<4.21.3 || >4.21.3,<4.21.4 || >4.21.4,<4.21.5 || >4.21.5,<5.0.0dev"
 six = ">=1.12.0"
-tensorboard = ">=2.12,<2.13"
-tensorflow-estimator = ">=2.12.0,<2.13"
+tensorboard = ">=2.13,<2.14"
+tensorflow-estimator = ">=2.13.0,<2.14"
 tensorflow-io-gcs-filesystem = {version = ">=0.23.1", markers = "platform_machine != \"arm64\" or platform_system != \"Darwin\""}
 termcolor = ">=1.1.0"
-typing-extensions = ">=3.6.6"
-wrapt = ">=1.11.0,<1.15"
+typing-extensions = ">=3.6.6,<4.6.0"
+wrapt = ">=1.11.0"
 
 [[package]]
 name = "tensorflow-estimator"
-version = "2.12.0"
+version = "2.13.0"
 description = "TensorFlow Estimator."
 category = "main"
 optional = false
@@ -798,7 +736,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "flake8 (<5)", "pytest-co
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8,<3.12"
-content-hash = "c906ccdf13889b41833c6785a6d00828cc1ae6744c1b089588812533841c413f"
+content-hash = "1f2c0ce6f53565271820d57ce356e59d3a0a18785a845b027db8672368dd28b1"
 
 [metadata.files]
 absl-py = []
@@ -839,13 +777,11 @@ idna = []
 importlib-metadata = []
 iniconfig = []
 itsdangerous = []
-jax = []
 jinja2 = []
 keras = []
 libclang = []
 markdown = []
 markupsafe = []
-ml-dtypes = []
 mock = []
 numpy = []
 oauthlib = []
@@ -903,7 +839,6 @@ requests-oauthlib = [
     {file = "requests_oauthlib-1.3.1-py2.py3-none-any.whl", hash = "sha256:2577c501a2fb8d05a304c09d090d6e47c306fef15809d102b327cf8364bddab5"},
 ]
 rsa = []
-scipy = []
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
     {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,10 +9,10 @@ license = "MIT"
 
 [tool.poetry.dependencies]
 python = ">=3.8,<3.12"
-tensorflow = "<=2.12"
+tensorflow = "<=2.14.0"
 Flask = "^2.2.3"
 h5py = "3.8.0"
-pyspark = "<=3.3"
+pyspark = "<=3.5.0"
 Cython = "^0.29.33"
 numpy = "1.23.5"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ license = "MIT"
 
 [tool.poetry.dependencies]
 python = ">=3.8,<3.12"
-tensorflow = ">2.2,<=2.10"
+tensorflow = "<=2.12"
 Flask = "^2.2.3"
 h5py = "3.8.0"
 pyspark = "<=3.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "elephas"
-version = "4.2.0"
+version = "5.0.0"
 description = "Distributed deep learning on Spark with Keras"
 readme = "README.md"
 homepage = "https://danielenricocahall.github.io/elephas/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ license = "MIT"
 
 [tool.poetry.dependencies]
 python = ">=3.8,<3.12"
-tensorflow = "<=2.14.0"
+tensorflow = ">2.2,<=2.14"
 Flask = "^2.2.3"
 h5py = "3.8.0"
 pyspark = "<=3.5.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "elephas"
-version = "4.1.0"
+version = "4.2.0"
 description = "Distributed deep learning on Spark with Keras"
 readme = "README.md"
 homepage = "https://danielenricocahall.github.io/elephas/"
@@ -8,7 +8,7 @@ authors = ["Daniel Cahall <danielenricocahall@gmail.com>"]
 license = "MIT"
 
 [tool.poetry.dependencies]
-python = ">=3.8,<3.11"
+python = ">=3.8,<3.12"
 tensorflow = ">2.2,<=2.10"
 Flask = "^2.2.3"
 h5py = "3.8.0"

--- a/tests/integration/test_custom_models.py
+++ b/tests/integration/test_custom_models.py
@@ -5,7 +5,7 @@ import pytest
 from tensorflow.keras.backend import sigmoid
 from tensorflow.keras.models import Sequential
 from tensorflow.keras.layers import Dense
-from tensorflow.keras.optimizers import SGD
+from tensorflow.keras.optimizers.legacy import SGD
 
 from elephas.spark_model import SparkModel
 from elephas.utils import to_simple_rdd

--- a/tests/integration/test_end_to_end.py
+++ b/tests/integration/test_end_to_end.py
@@ -1,7 +1,7 @@
 from itertools import count
 from math import isclose
 
-from tensorflow.keras.optimizers import SGD
+from tensorflow.keras.optimizers.legacy import SGD
 
 from elephas.spark_model import SparkModel
 from elephas.utils.rdd_utils import to_simple_rdd

--- a/tests/test_ml_model.py
+++ b/tests/test_ml_model.py
@@ -65,7 +65,7 @@ def test_spark_ml_model_classification(spark_context, classification_model, mnis
     df = to_data_frame(spark_context, x_train, y_train, categorical=True)
     test_df = to_data_frame(spark_context, x_test, y_test, categorical=True)
 
-    sgd = optimizers.SGD(learning_rate=0.01, decay=1e-6, momentum=0.9, nesterov=True)
+    sgd = optimizers.SGD(learning_rate=0.01, weight_decay=1e-6, momentum=0.9, nesterov=True)
     sgd_conf = optimizers.serialize(sgd)
 
     # Initialize Spark ML Estimator
@@ -283,7 +283,7 @@ def test_predict_classes_probability(spark_context, classification_model, mnist_
     df = to_data_frame(spark_context, x_train, y_train, categorical=True)
     test_df = to_data_frame(spark_context, x_test, y_test, categorical=True)
 
-    sgd = optimizers.SGD(learning_rate=0.01, decay=1e-6, momentum=0.9, nesterov=True)
+    sgd = optimizers.SGD(learning_rate=0.01, weight_decay=1e-6, momentum=0.9, nesterov=True)
     sgd_conf = optimizers.serialize(sgd)
 
     # Initialize Spark ML Estimator
@@ -320,7 +320,7 @@ def test_batch_predict_classes_probability(spark_context, classification_model, 
     df = to_data_frame(spark_context, x_train, y_train, categorical=True)
     test_df = to_data_frame(spark_context, x_test, y_test, categorical=True)
 
-    sgd = optimizers.SGD(learning_rate=0.01, decay=1e-6, momentum=0.9, nesterov=True)
+    sgd = optimizers.SGD(learning_rate=0.01, weight_decay=1e-6, momentum=0.9, nesterov=True)
     sgd_conf = optimizers.serialize(sgd)
 
     # Initialize Spark ML Estimator
@@ -355,7 +355,7 @@ def test_batch_predict_classes_probability(spark_context, classification_model, 
 
 
 def test_save_pipeline(spark_context, classification_model):
-    sgd = optimizers.SGD(learning_rate=0.01, decay=1e-6, momentum=0.9, nesterov=True)
+    sgd = optimizers.SGD(learning_rate=0.01, weight_decay=1e-6, momentum=0.9, nesterov=True)
     sgd_conf = optimizers.serialize(sgd)
 
     # Initialize Spark ML Estimator

--- a/tests/test_ml_model.py
+++ b/tests/test_ml_model.py
@@ -7,7 +7,7 @@ from pyspark.mllib.evaluation import MulticlassMetrics, RegressionMetrics
 from pyspark.sql import Column
 from pyspark.sql.types import DoubleType
 import pyspark.sql.functions as F
-from tensorflow.keras import optimizers
+from tensorflow.keras.optimizers.legacy import SGD, serialize
 from tensorflow.keras.activations import relu
 from tensorflow.keras.layers import Dense
 from tensorflow.keras.models import Sequential
@@ -65,8 +65,8 @@ def test_spark_ml_model_classification(spark_context, classification_model, mnis
     df = to_data_frame(spark_context, x_train, y_train, categorical=True)
     test_df = to_data_frame(spark_context, x_test, y_test, categorical=True)
 
-    sgd = optimizers.SGD(learning_rate=0.01, weight_decay=1e-6, momentum=0.9, nesterov=True)
-    sgd_conf = optimizers.serialize(sgd)
+    sgd = SGD(learning_rate=0.01, weight_decay=1e-6, momentum=0.9, nesterov=True)
+    sgd_conf = serialize(sgd)
 
     # Initialize Spark ML Estimator
     estimator = ElephasEstimator()
@@ -108,8 +108,8 @@ def test_functional_model(spark_context, classification_model_functional, mnist_
     df = to_data_frame(spark_context, x_train, y_train, categorical=True)
     test_df = to_data_frame(spark_context, x_test, y_test, categorical=True)
 
-    sgd = optimizers.SGD()
-    sgd_conf = optimizers.serialize(sgd)
+    sgd = SGD()
+    sgd_conf = serialize(sgd)
     estimator = ElephasEstimator()
     estimator.set_keras_model_config(classification_model_functional.to_json())
     estimator.set_optimizer_config(sgd_conf)
@@ -141,8 +141,8 @@ def test_regression_model(spark_context, regression_model, boston_housing_datase
     df = to_data_frame(spark_context, x_train, y_train)
     test_df = to_data_frame(spark_context, x_test, y_test)
 
-    sgd = optimizers.SGD(learning_rate=0.00001)
-    sgd_conf = optimizers.serialize(sgd)
+    sgd = SGD(learning_rate=0.00001)
+    sgd_conf = serialize(sgd)
     estimator = ElephasEstimator()
     estimator.set_keras_model_config(regression_model.to_json())
     estimator.set_optimizer_config(sgd_conf)
@@ -178,8 +178,8 @@ def test_set_cols_deprecated(spark_context, regression_model, boston_housing_dat
         test_df = test_df.withColumnRenamed('features', 'scaled_features')
         test_df = test_df.withColumnRenamed('label', 'ground_truth')
 
-        sgd = optimizers.SGD(learning_rate=0.00001)
-        sgd_conf = optimizers.serialize(sgd)
+        sgd = SGD(learning_rate=0.00001)
+        sgd_conf = serialize(sgd)
         estimator = ElephasEstimator()
         estimator.set_keras_model_config(regression_model.to_json())
         estimator.set_optimizer_config(sgd_conf)
@@ -217,8 +217,8 @@ def test_set_cols(spark_context, regression_model, boston_housing_dataset):
     test_df = test_df.withColumnRenamed('features', 'scaled_features')
     test_df = test_df.withColumnRenamed('label', 'ground_truth')
 
-    sgd = optimizers.SGD(learning_rate=0.00001)
-    sgd_conf = optimizers.serialize(sgd)
+    sgd = SGD(learning_rate=0.00001)
+    sgd_conf = serialize(sgd)
     estimator = ElephasEstimator(labelCol='ground_truth', outputCol='output', featuresCol='scaled_features')
     estimator.set_keras_model_config(regression_model.to_json())
     estimator.set_optimizer_config(sgd_conf)
@@ -253,8 +253,8 @@ def test_custom_objects(spark_context, boston_housing_dataset):
     df = to_data_frame(spark_context, x_train, y_train)
     test_df = to_data_frame(spark_context, x_test, y_test)
 
-    sgd = optimizers.SGD(learning_rate=0.00001)
-    sgd_conf = optimizers.serialize(sgd)
+    sgd = SGD(learning_rate=0.00001)
+    sgd_conf = serialize(sgd)
     estimator = ElephasEstimator()
     estimator.set_keras_model_config(model.to_json())
     estimator.set_optimizer_config(sgd_conf)
@@ -283,8 +283,8 @@ def test_predict_classes_probability(spark_context, classification_model, mnist_
     df = to_data_frame(spark_context, x_train, y_train, categorical=True)
     test_df = to_data_frame(spark_context, x_test, y_test, categorical=True)
 
-    sgd = optimizers.SGD(learning_rate=0.01, weight_decay=1e-6, momentum=0.9, nesterov=True)
-    sgd_conf = optimizers.serialize(sgd)
+    sgd = SGD(learning_rate=0.01, weight_decay=1e-6, momentum=0.9, nesterov=True)
+    sgd_conf = serialize(sgd)
 
     # Initialize Spark ML Estimator
     estimator = ElephasEstimator()
@@ -320,8 +320,8 @@ def test_batch_predict_classes_probability(spark_context, classification_model, 
     df = to_data_frame(spark_context, x_train, y_train, categorical=True)
     test_df = to_data_frame(spark_context, x_test, y_test, categorical=True)
 
-    sgd = optimizers.SGD(learning_rate=0.01, weight_decay=1e-6, momentum=0.9, nesterov=True)
-    sgd_conf = optimizers.serialize(sgd)
+    sgd = SGD(learning_rate=0.01, weight_decay=1e-6, momentum=0.9, nesterov=True)
+    sgd_conf = serialize(sgd)
 
     # Initialize Spark ML Estimator
     estimator = ElephasEstimator()
@@ -355,8 +355,8 @@ def test_batch_predict_classes_probability(spark_context, classification_model, 
 
 
 def test_save_pipeline(spark_context, classification_model):
-    sgd = optimizers.SGD(learning_rate=0.01, weight_decay=1e-6, momentum=0.9, nesterov=True)
-    sgd_conf = optimizers.serialize(sgd)
+    sgd = SGD(learning_rate=0.01, weight_decay=1e-6, momentum=0.9, nesterov=True)
+    sgd_conf = serialize(sgd)
 
     # Initialize Spark ML Estimator
     estimator = ElephasEstimator()

--- a/tests/test_ml_model.py
+++ b/tests/test_ml_model.py
@@ -7,7 +7,8 @@ from pyspark.mllib.evaluation import MulticlassMetrics, RegressionMetrics
 from pyspark.sql import Column
 from pyspark.sql.types import DoubleType
 import pyspark.sql.functions as F
-from tensorflow.keras.optimizers.legacy import SGD, serialize
+from tensorflow.keras import optimizers
+from tensorflow.keras.optimizers.legacy import SGD
 from tensorflow.keras.activations import relu
 from tensorflow.keras.layers import Dense
 from tensorflow.keras.models import Sequential
@@ -65,8 +66,8 @@ def test_spark_ml_model_classification(spark_context, classification_model, mnis
     df = to_data_frame(spark_context, x_train, y_train, categorical=True)
     test_df = to_data_frame(spark_context, x_test, y_test, categorical=True)
 
-    sgd = SGD(learning_rate=0.01, weight_decay=1e-6, momentum=0.9, nesterov=True)
-    sgd_conf = serialize(sgd)
+    sgd = SGD(learning_rate=0.01, decay=1e-6, momentum=0.9, nesterov=True)
+    sgd_conf = optimizers.serialize(sgd)
 
     # Initialize Spark ML Estimator
     estimator = ElephasEstimator()
@@ -109,7 +110,7 @@ def test_functional_model(spark_context, classification_model_functional, mnist_
     test_df = to_data_frame(spark_context, x_test, y_test, categorical=True)
 
     sgd = SGD()
-    sgd_conf = serialize(sgd)
+    sgd_conf = optimizers.serialize(sgd)
     estimator = ElephasEstimator()
     estimator.set_keras_model_config(classification_model_functional.to_json())
     estimator.set_optimizer_config(sgd_conf)
@@ -142,7 +143,7 @@ def test_regression_model(spark_context, regression_model, boston_housing_datase
     test_df = to_data_frame(spark_context, x_test, y_test)
 
     sgd = SGD(learning_rate=0.00001)
-    sgd_conf = serialize(sgd)
+    sgd_conf = optimizers.serialize(sgd)
     estimator = ElephasEstimator()
     estimator.set_keras_model_config(regression_model.to_json())
     estimator.set_optimizer_config(sgd_conf)
@@ -179,7 +180,7 @@ def test_set_cols_deprecated(spark_context, regression_model, boston_housing_dat
         test_df = test_df.withColumnRenamed('label', 'ground_truth')
 
         sgd = SGD(learning_rate=0.00001)
-        sgd_conf = serialize(sgd)
+        sgd_conf = optimizers.serialize(sgd)
         estimator = ElephasEstimator()
         estimator.set_keras_model_config(regression_model.to_json())
         estimator.set_optimizer_config(sgd_conf)
@@ -218,7 +219,7 @@ def test_set_cols(spark_context, regression_model, boston_housing_dataset):
     test_df = test_df.withColumnRenamed('label', 'ground_truth')
 
     sgd = SGD(learning_rate=0.00001)
-    sgd_conf = serialize(sgd)
+    sgd_conf = optimizers.serialize(sgd)
     estimator = ElephasEstimator(labelCol='ground_truth', outputCol='output', featuresCol='scaled_features')
     estimator.set_keras_model_config(regression_model.to_json())
     estimator.set_optimizer_config(sgd_conf)
@@ -254,7 +255,7 @@ def test_custom_objects(spark_context, boston_housing_dataset):
     test_df = to_data_frame(spark_context, x_test, y_test)
 
     sgd = SGD(learning_rate=0.00001)
-    sgd_conf = serialize(sgd)
+    sgd_conf = optimizers.serialize(sgd)
     estimator = ElephasEstimator()
     estimator.set_keras_model_config(model.to_json())
     estimator.set_optimizer_config(sgd_conf)
@@ -283,8 +284,8 @@ def test_predict_classes_probability(spark_context, classification_model, mnist_
     df = to_data_frame(spark_context, x_train, y_train, categorical=True)
     test_df = to_data_frame(spark_context, x_test, y_test, categorical=True)
 
-    sgd = SGD(learning_rate=0.01, weight_decay=1e-6, momentum=0.9, nesterov=True)
-    sgd_conf = serialize(sgd)
+    sgd = SGD(learning_rate=0.01, decay=1e-6, momentum=0.9, nesterov=True)
+    sgd_conf = optimizers.serialize(sgd)
 
     # Initialize Spark ML Estimator
     estimator = ElephasEstimator()
@@ -320,8 +321,8 @@ def test_batch_predict_classes_probability(spark_context, classification_model, 
     df = to_data_frame(spark_context, x_train, y_train, categorical=True)
     test_df = to_data_frame(spark_context, x_test, y_test, categorical=True)
 
-    sgd = SGD(learning_rate=0.01, weight_decay=1e-6, momentum=0.9, nesterov=True)
-    sgd_conf = serialize(sgd)
+    sgd = SGD(learning_rate=0.01, decay=1e-6, momentum=0.9, nesterov=True)
+    sgd_conf = optimizers.serialize(sgd)
 
     # Initialize Spark ML Estimator
     estimator = ElephasEstimator()
@@ -355,8 +356,8 @@ def test_batch_predict_classes_probability(spark_context, classification_model, 
 
 
 def test_save_pipeline(spark_context, classification_model):
-    sgd = SGD(learning_rate=0.01, weight_decay=1e-6, momentum=0.9, nesterov=True)
-    sgd_conf = serialize(sgd)
+    sgd = SGD(learning_rate=0.01, decay=1e-6, momentum=0.9, nesterov=True)
+    sgd_conf = optimizers.serialize(sgd)
 
     # Initialize Spark ML Estimator
     estimator = ElephasEstimator()

--- a/tests/test_mllib_model.py
+++ b/tests/test_mllib_model.py
@@ -1,5 +1,5 @@
 
-from tensorflow.keras.optimizers import RMSprop
+from tensorflow.keras.optimizers.legacy import RMSprop
 
 from elephas.spark_model import SparkMLlibModel, load_spark_model
 from elephas.utils.rdd_utils import to_labeled_point


### PR DESCRIPTION
Updating to support Python 3.11, which also requires supporting later versions of Tensorflow (> 2.10). When Tensorflow is updated, however, we get the following error in multiple unit tests:
```
self = <pyspark.cloudpickle.cloudpickle_fast.CloudPickler object at 0x7fe7fc26a1c0>
obj = (<function RDD.mapPartitions.<locals>.func at 0x7fe80bb3a790>, None, BatchedSerializer(CloudPickleSerializer(), 10), AutoBatchedSerializer(CloudPickleSerializer()))

    def dump(self, obj):
        try:
>           return Pickler.dump(self, obj)
E           TypeError: cannot pickle 'weakref' object
```

Upon reviewing the Tensorflow releases, one highlight in the [2.11.0 release notes](https://github.com/tensorflow/tensorflow/releases/tag/v2.11.0) is the `tf.keras.optimizers.Optimizer` now uses the new base class. When the optimizer import is changed to `tf.keras.optimizers.legacy`, the tests pass. This suggests that something in the new Optimizer implementation is not serializable. 

Per the notes, _"The old Keras optimizer will never be deleted, but will not see any new feature additions."_, so we can continue using the legacy optimizer indefinitely, although as a long-term strategy I would like to see if there is a work around to enable developers to use the new optimizer. I have created an Issue to track this [here](https://github.com/danielenricocahall/elephas/issues/26)