### PR TITLE
Add multi-input/output support

### DIFF
--- a/elephas/enums/frequency.py
+++ b/elephas/enums/frequency.py
@@ -1,0 +1,20 @@
+import sys
+
+if sys.version_info.minor < 11:
+    # Devs using version < 3.11 can use the str enum mixin
+    from enum import Enum
+
+
+    class Frequency(str, Enum):
+        EPOCH: str = 'epoch'
+        BATCH: str = 'batch'
+else:
+    # Devs using version >= 3.11 can use the strenum builtin,
+    # but that breaks the mixin implementation
+    # https://github.com/python/cpython/issues/100458
+    from enum import StrEnum, auto
+
+
+    class Frequency(StrEnum):
+        EPOCH = auto()
+        BATCH = auto()

--- a/elephas/worker.py
+++ b/elephas/worker.py
@@ -4,6 +4,7 @@ from tensorflow.keras.models import model_from_json
 from tensorflow.keras.optimizers import get as get_optimizer
 from tensorflow.python.keras.utils.generic_utils import slice_arrays
 
+from .enums.frequency import Frequency
 from .utils import subtract_params
 from .parameter import BaseParameterClient
 
@@ -118,7 +119,7 @@ class AsynchronousSparkWorker(object):
             for i in range(0, nb_batch)
         ]
 
-        if self.frequency == 'epoch':
+        if self.frequency == Frequency.EPOCH:
             for epoch in range(epochs):
                 weights_before_training = self.client.get_parameters()
                 self.model.set_weights(weights_before_training)
@@ -130,7 +131,7 @@ class AsynchronousSparkWorker(object):
                 deltas = subtract_params(
                     weights_before_training, weights_after_training)
                 self.client.update_parameters(deltas)
-        elif self.frequency == 'batch':
+        elif self.frequency == Frequency.BATCH:
             for epoch in range(epochs):
                 if nb_train_sample > batch_size:
                     for (batch_start, batch_end) in batches:

--- a/elephas/worker.py
+++ b/elephas/worker.py
@@ -93,8 +93,8 @@ class AsynchronousSparkWorker(object):
         nb_train_sample = x_train.shape[0]
 
         self.model = model_from_json(self.json, self.custom_objects)
-        #if is_multiple_input_model(self.model):
-        #    x_train = np.hsplit(x_train, len(self.model.input_shape))
+        if is_multiple_input_model(self.model):
+            x_train = np.hsplit(x_train, len(self.model.input_shape))
         self.model.compile(optimizer=get_optimizer(self.master_optimizer),
                            loss=self.master_loss, metrics=self.master_metrics)
         self.model.set_weights(self.parameters.value)

--- a/tests/integration/test_end_to_end.py
+++ b/tests/integration/test_end_to_end.py
@@ -1,5 +1,5 @@
 import os
-import socket
+from itertools import count
 from math import isclose
 
 from keras import Model
@@ -17,15 +17,8 @@ import pytest
 import numpy as np
 
 
-def _generate_port_number(start_port=50000, end_port=60000):
-    for port in range(start_port, end_port):
-        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-            try:
-                s.bind(("", port))
-                return port
-            except OSError:
-                continue
-    raise RuntimeError("No available ports in the range.")
+def _generate_port_number(port=3000, _count=count(1)):
+    return port + next(_count)
 
 
 COMBINATIONS = [(Mode.SYNCHRONOUS, None, None),

--- a/tests/integration/test_end_to_end.py
+++ b/tests/integration/test_end_to_end.py
@@ -8,6 +8,7 @@ from tensorflow.keras import Input
 from tensorflow.keras.layers import Embedding, Flatten, Dot
 
 from elephas.enums.modes import Mode
+from elephas.enums.frequency import Frequency
 from elephas.spark_model import SparkModel
 from elephas.utils.rdd_utils import to_simple_rdd
 
@@ -143,7 +144,7 @@ def test_training_regression_no_metrics(spark_context, boston_housing_dataset, r
                    spark_model.master_network.evaluate(x_test, y_test), abs_tol=0.01)
 
 
-@pytest.mark.parametrize('frequency', ['epoch', 'batch'])
+@pytest.mark.parametrize('frequency', [Frequency.EPOCH, Frequency.BATCH])
 def test_multiple_input_model(spark_session, frequency):
     def row_to_tuple(row):
         return [row.user_id_encoded, row.track_id_encoded], row.frequency

--- a/tests/integration/test_end_to_end.py
+++ b/tests/integration/test_end_to_end.py
@@ -1,3 +1,4 @@
+import os
 from itertools import count
 from math import isclose
 
@@ -150,7 +151,9 @@ def test_multiple_input_model(spark_session, frequency):
         return [row.user_id_encoded, row.track_id_encoded], row.frequency
 
     # Read and preprocess data
-    df = spark_session.read.csv('sample_data.csv', header=True, inferSchema=True)
+    current_dir = os.path.dirname(__file__)
+    parent_dir = os.path.dirname(current_dir)
+    df = spark_session.read.csv(f'{parent_dir}/data/sample_data.csv', header=True, inferSchema=True)
     df = df.limit(100)
 
     indexer_user = StringIndexer(inputCol="user_id", outputCol="user_id_encoded")

--- a/tests/integration/test_end_to_end.py
+++ b/tests/integration/test_end_to_end.py
@@ -1,4 +1,5 @@
 import os
+import socket
 from itertools import count
 from math import isclose
 
@@ -17,8 +18,15 @@ import pytest
 import numpy as np
 
 
-def _generate_port_number(port=3000, _count=count(1)):
-    return port + next(_count)
+def _generate_port_number(start_port=50000, end_port=60000):
+    for port in range(start_port, end_port):
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            try:
+                s.bind(("", port))
+                return port
+            except OSError:
+                continue
+    raise RuntimeError("No available ports in the range.")
 
 
 COMBINATIONS = [(Mode.SYNCHRONOUS, None, None),

--- a/tests/integration/test_end_to_end.py
+++ b/tests/integration/test_end_to_end.py
@@ -129,7 +129,7 @@ def test_training_regression_no_metrics(spark_context, boston_housing_dataset, r
     epochs = 1
     sgd = SGD(lr=0.0000001)
     regression_model.compile(sgd, 'mse')
-    spark_model = SparkModel(regression_model, frequency='epoch', mode=Mode.ASYNCHRONOUS, port=_generate_port_number())
+    spark_model = SparkModel(regression_model, frequency='epoch', mode=Mode.SYNCHRONOUS, port=_generate_port_number())
 
     # Train Spark model
     spark_model.fit(rdd, epochs=epochs, batch_size=batch_size, verbose=0, validation_split=0.1)

--- a/tests/integration/test_end_to_end.py
+++ b/tests/integration/test_end_to_end.py
@@ -1,6 +1,5 @@
 import os
 import socket
-from itertools import count
 from math import isclose
 
 from keras import Model

--- a/tests/integration/test_end_to_end.py
+++ b/tests/integration/test_end_to_end.py
@@ -1,7 +1,11 @@
 from itertools import count
 from math import isclose
 
+from keras import Model
+from pyspark.ml.feature import StringIndexer, VectorAssembler
 from tensorflow.keras.optimizers.legacy import SGD
+from tensorflow.keras import Input
+from tensorflow.keras.layers import Embedding, Flatten, Dot
 
 from elephas.enums.modes import Mode
 from elephas.spark_model import SparkModel
@@ -125,7 +129,7 @@ def test_training_regression_no_metrics(spark_context, boston_housing_dataset, r
     epochs = 1
     sgd = SGD(lr=0.0000001)
     regression_model.compile(sgd, 'mse')
-    spark_model = SparkModel(regression_model, frequency='epoch', mode=Mode.SYNCHRONOUS, port=_generate_port_number())
+    spark_model = SparkModel(regression_model, frequency='epoch', mode=Mode.ASYNCHRONOUS, port=_generate_port_number())
 
     # Train Spark model
     spark_model.fit(rdd, epochs=epochs, batch_size=batch_size, verbose=0, validation_split=0.1)
@@ -145,4 +149,39 @@ def test_training_regression_no_metrics(spark_context, boston_housing_dataset, r
                    spark_model.master_network.evaluate(x_test, y_test), abs_tol=0.01)
 
 
+def test_multiple_input_model(spark_session):
 
+    def row_to_tuple(row):
+        return ([row.user_id_encoded, row.track_id_encoded], row.frequency)
+
+    # Read and preprocess data
+    df = spark_session.read.csv('sample_data.csv', header=True, inferSchema=True)
+    df = df.limit(100)
+
+    indexer_user = StringIndexer(inputCol="user_id", outputCol="user_id_encoded")
+    df = indexer_user.fit(df).transform(df)
+    indexer_track = StringIndexer(inputCol="track_id", outputCol="track_id_encoded")
+    df = indexer_track.fit(df).transform(df)
+
+    assembler = VectorAssembler(inputCols=["user_id_encoded", "track_id_encoded"], outputCol="features")
+    df_transformed = assembler.transform(df)
+
+    # Keras model inputs
+    n_users = df.select('user_id').distinct().count()
+    n_items = df.select('track_id').distinct().count()
+    n_latent_factors = 50  # Example
+
+    user_input = Input(shape=(1,), name='user_input')
+    item_input = Input(shape=(1,), name='item_input')
+    user_embedding = Embedding(output_dim=n_latent_factors, input_dim=n_users)(user_input)
+    item_embedding = Embedding(output_dim=n_latent_factors, input_dim=n_items)(item_input)
+    user_vec = Flatten()(user_embedding)
+    item_vec = Flatten()(item_embedding)
+    dot = Dot(axes=1)([user_vec, item_vec])
+    model = Model([user_input, item_input], dot)
+    model.compile(optimizer=SGD(), loss='mean_squared_error')
+
+    rdd_final = df_transformed.rdd.map(row_to_tuple)
+
+    spark_model = SparkModel(model, frequency='epoch', mode='asynchronous')
+    spark_model.fit(rdd_final, epochs=5, batch_size=32, verbose=0, validation_split=0.1)

--- a/tests/integration/test_end_to_end.py
+++ b/tests/integration/test_end_to_end.py
@@ -154,7 +154,6 @@ def test_multiple_input_model(spark_session, frequency):
     current_dir = os.path.dirname(__file__)
     parent_dir = os.path.dirname(current_dir)
     df = spark_session.read.csv(f'{parent_dir}/data/sample_data.csv', header=True, inferSchema=True)
-    df = df.limit(100)
 
     indexer_user = StringIndexer(inputCol="user_id", outputCol="user_id_encoded")
     df = indexer_user.fit(df).transform(df)


### PR DESCRIPTION
Using the data graciously provided in https://github.com/danielenricocahall/elephas/issues/30 as part of another debugging effort, this PR adds support for training Keras models which require multiple inputs and outputs. This is a feature which was requested previously:

- https://github.com/maxpumperla/elephas/issues/145
- https://github.com/maxpumperla/elephas/issues/127

But never introduced due to presumed limitations.