### PR TITLE
Inference and evaluation support for multiple input/output models

### DIFF
--- a/elephas/utils/model_utils.py
+++ b/elephas/utils/model_utils.py
@@ -1,9 +1,5 @@
 import json
 from enum import Enum
-from typing import Union
-
-from pyspark.sql import Column
-import pyspark.sql.functions as F
 
 
 class ModelType(Enum):
@@ -68,3 +64,15 @@ def as_enum(d):
         return getattr(ModelType, member)
     else:
         return d
+
+
+def is_multiple_input_model(model) -> bool:
+    """Check if a model has multiple inputs
+    """
+    return isinstance(model.input_shape, list)
+
+
+def is_multiple_output_model(model) -> bool:
+    """Check if a model has multiple outputs
+    """
+    return isinstance(model.output_shape, list)

--- a/elephas/worker.py
+++ b/elephas/worker.py
@@ -7,18 +7,7 @@ from tensorflow.python.keras.utils.generic_utils import slice_arrays
 from .enums.frequency import Frequency
 from .utils import subtract_params
 from .parameter import BaseParameterClient
-
-
-def is_multiple_input_model(model):
-    """Check if a model has multiple inputs
-    """
-    return isinstance(model.input_shape, list)
-
-
-def is_multiple_output_model(model):
-    """Check if a model has multiple outputs
-    """
-    return isinstance(model.output_shape, list)
+from .utils.model_utils import is_multiple_input_model, is_multiple_output_model
 
 
 class SparkWorker(object):

--- a/tests/integration/test_end_to_end.py
+++ b/tests/integration/test_end_to_end.py
@@ -182,3 +182,7 @@ def test_multiple_input_model(spark_session, frequency):
 
     spark_model = SparkModel(model, frequency=frequency, mode=Mode.ASYNCHRONOUS, port=_generate_port_number())
     spark_model.fit(rdd_final, epochs=5, batch_size=32, verbose=0, validation_split=0.1)
+    rdd_test_data = rdd_final.map(lambda x: x[0])
+    rdd_test_targets = rdd_final.map(lambda x: x[1])
+    assert spark_model.predict(rdd_test_data)
+    assert spark_model.evaluate(np.array(rdd_test_data.collect()), np.array(rdd_test_targets.collect()))


### PR DESCRIPTION
In https://github.com/danielenricocahall/elephas/pull/31, support was added for training multiple input/output models. This PR extends that capability by enabling inference and evaluation of multiple input/output models.