### PR TITLE
perf: drop NPZ compression on parameter-server wire format

### DIFF
--- a/elephas/parameter/client.py
+++ b/elephas/parameter/client.py
@@ -5,7 +5,7 @@ import socket
 
 import urllib.request as urllib2
 
-from ..utils import npz_bytes_to_weights, weights_to_npz_bytes
+from ..utils import bytes_to_weights, weights_to_bytes
 from ..utils.sockets import determine_master, recv_bytes, send_bytes
 
 
@@ -58,10 +58,10 @@ class HttpClient(BaseParameterClient):
             f"http://{self.master_url}/parameters", headers=self.headers
         )
         blob = urllib2.urlopen(request).read()
-        return npz_bytes_to_weights(blob)
+        return bytes_to_weights(blob)
 
     def update_parameters(self, delta: list):
-        blob = weights_to_npz_bytes(delta)
+        blob = weights_to_bytes(delta)
         request = urllib2.Request(
             f"http://{self.master_url}/update", data=blob, headers=self.headers
         )
@@ -86,12 +86,12 @@ class SocketClient(BaseParameterClient):
             sock.connect((host, self.port))
             sock.sendall(b"g")
             blob = recv_bytes(sock)
-        return npz_bytes_to_weights(blob)
+        return bytes_to_weights(blob)
 
     def update_parameters(self, delta: list):
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
             host = determine_master(port=self.port).split(":")[0]
             sock.connect((host, self.port))
             sock.sendall(b"u")
-            blob = weights_to_npz_bytes(delta)
+            blob = weights_to_bytes(delta)
             send_bytes(sock, blob)

--- a/elephas/parameter/server.py
+++ b/elephas/parameter/server.py
@@ -11,8 +11,8 @@ from elephas.utils.sockets import determine_master
 from elephas.utils.sockets import recv_bytes, send_bytes
 from elephas.utils.serialization import (
     dict_to_model,
-    weights_to_npz_bytes,
-    npz_bytes_to_weights,
+    weights_to_bytes,
+    bytes_to_weights,
 )
 from elephas.utils.rwlock import RWLock as Lock
 from elephas.utils.notebook_utils import is_running_in_notebook
@@ -127,13 +127,13 @@ class HttpServer(BaseParameterServer):
         @app.route("/parameters", methods=["GET"])
         @self.make_read_threadsafe_if_necessary
         def handle_get_parameters():
-            payload = weights_to_npz_bytes(self.weights)
+            payload = weights_to_bytes(self.weights)
             return Response(payload, mimetype="application/octet-stream")
 
         @app.route("/update", methods=["POST"])
         @self.make_write_threadsafe_if_necessary
         def handle_update_parameters():
-            delta = npz_bytes_to_weights(request.data)
+            delta = bytes_to_weights(request.data)
             if not self.master_network.built:
                 self.master_network.build()
             weights_before = self.weights
@@ -220,13 +220,13 @@ class SocketServer(BaseParameterServer):
 
     def update_parameters(self, conn):
         blob = recv_bytes(conn)
-        delta = npz_bytes_to_weights(blob)
+        delta = bytes_to_weights(blob)
         weights = self.master_network.get_weights()
         self.master_network.set_weights(subtract_params(weights, delta))
 
     def get_parameters(self, conn):
         weights = self.master_network.get_weights()
-        blob = weights_to_npz_bytes(weights)
+        blob = weights_to_bytes(weights)
         send_bytes(conn, blob)
 
     def action_listener(self, conn):

--- a/elephas/utils/serialization.py
+++ b/elephas/utils/serialization.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any, Optional
+from typing import Dict, Any, List, Optional
 
 import io
 import numpy as np
@@ -30,15 +30,48 @@ def dict_to_model(
     return model
 
 
-def weights_to_npz_bytes(weights):
-    """weights: list[np.ndarray]"""
-    buf = io.BytesIO()
-    # name each array deterministically for order
-    np.savez_compressed(buf, **{f"arr{i}": w for i, w in enumerate(weights)})
-    return buf.getvalue()
+def weights_to_bytes(weights: List[np.ndarray]) -> bytes:
+    """Serialize a list of numpy arrays to a self-describing byte string.
+
+    Format (all little-endian, no compression): uint32 count, then for each array
+    uint8 ndim, int64[ndim] shape, uint16 dtype_str_len, ascii dtype_str,
+    uint64 nbytes, raw payload.
+    """
+    out = io.BytesIO()
+    out.write(np.uint32(len(weights)).tobytes())
+    for w in weights:
+        w = np.ascontiguousarray(w)
+        dt = str(w.dtype).encode("ascii")
+        out.write(np.uint8(w.ndim).tobytes())
+        out.write(np.asarray(w.shape, dtype=np.int64).tobytes())
+        out.write(np.uint16(len(dt)).tobytes())
+        out.write(dt)
+        out.write(np.uint64(w.nbytes).tobytes())
+        out.write(w.tobytes())
+    return out.getvalue()
 
 
-def npz_bytes_to_weights(b):
-    buf = io.BytesIO(b)
-    with np.load(buf) as z:
-        return [z[f"arr{i}"] for i in range(len(z.files))]
+def bytes_to_weights(b: bytes) -> List[np.ndarray]:
+    """Inverse of :func:`weights_to_bytes`."""
+    mv = memoryview(b)
+    off = 0
+    n = int(np.frombuffer(mv[off : off + 4], dtype=np.uint32)[0])
+    off += 4
+    out: List[np.ndarray] = []
+    for _ in range(n):
+        ndim = int(np.frombuffer(mv[off : off + 1], dtype=np.uint8)[0])
+        off += 1
+        shape = tuple(np.frombuffer(mv[off : off + 8 * ndim], dtype=np.int64).tolist())
+        off += 8 * ndim
+        dt_len = int(np.frombuffer(mv[off : off + 2], dtype=np.uint16)[0])
+        off += 2
+        dtype = np.dtype(bytes(mv[off : off + dt_len]).decode("ascii"))
+        off += dt_len
+        nbytes = int(np.frombuffer(mv[off : off + 8], dtype=np.uint64)[0])
+        off += 8
+        # frombuffer returns a read-only view into `b`; copy so the array is
+        # independently owned and may be mutated by callers.
+        arr = np.frombuffer(mv[off : off + nbytes], dtype=dtype).reshape(shape).copy()
+        off += nbytes
+        out.append(arr)
+    return out

--- a/tests/utils/test_serialization.py
+++ b/tests/utils/test_serialization.py
@@ -1,4 +1,4 @@
-import pytest
+import numpy as np
 from tensorflow.keras.models import Sequential
 from tensorflow.keras.layers import Dense
 
@@ -9,7 +9,7 @@ def test_model_to_dict():
     model = Sequential()
     model.add(Dense(1, "linear"))
     dict_model = serialization.model_to_dict(model)
-    assert list(dict_model.keys()) == ['model', 'weights']
+    assert list(dict_model.keys()) == ["model", "weights"]
 
 
 def test_dict_to_model():
@@ -19,3 +19,31 @@ def test_dict_to_model():
 
     recovered = serialization.dict_to_model(dict_model)
     assert recovered.to_json() == model.to_json()
+
+
+def test_weights_bytes_roundtrip_preserves_shape_dtype_and_values():
+    rng = np.random.default_rng(42)
+    weights = [
+        rng.standard_normal((4, 3), dtype=np.float32),
+        rng.standard_normal((3,), dtype=np.float32),
+        rng.integers(-5, 5, size=(2, 2), dtype=np.int64),
+        np.array([], dtype=np.float64),
+    ]
+
+    blob = serialization.weights_to_bytes(weights)
+    recovered = serialization.bytes_to_weights(blob)
+
+    assert len(recovered) == len(weights)
+    for original, restored in zip(weights, recovered):
+        assert original.shape == restored.shape
+        assert original.dtype == restored.dtype
+        assert np.array_equal(original, restored)
+
+
+def test_bytes_to_weights_returns_writable_arrays():
+    # frombuffer alone returns read-only views; callers mutate weights in place,
+    # so the decoder must return independently-owned arrays.
+    blob = serialization.weights_to_bytes([np.zeros(3, dtype=np.float32)])
+    arr = serialization.bytes_to_weights(blob)[0]
+    arr[0] = 1.0
+    assert arr[0] == 1.0


### PR DESCRIPTION
## Summary
- Replace `weights_to_npz_bytes` / `npz_bytes_to_weights` (which used `np.savez_compressed`) with `weights_to_bytes` / `bytes_to_weights`, a flat self-describing raw-byte format. Updated the only callers (`parameter/client.py`, `parameter/server.py`).
- Float32 model weights barely compress (~7%), but `savez_compressed` runs zlib over every payload on every parameter-server RPC. In `BATCH` update-frequency mode this fires per training batch.
- Added a serialization round-trip test (mixed dtypes incl. empty arrays) and a writability test — `np.frombuffer` returns read-only views, so the decoder must `.copy()` since callers mutate weights in place.

## Benchmark
Round-trip on a synthetic ~25M-param model (~119 MB float32, resnet-shaped):

| op     | NPZ (compressed) | raw bytes | speedup |
|--------|-----------------:|----------:|--------:|
| encode |          3578 ms |     27 ms |   ~135x |
| decode |           299 ms |     19 ms |    ~16x |
| size   |           110 MB |    119 MB |    +8%  |

Smaller models show the same shape (e.g. medium CNN: encode 292 ms → 1.3 ms). Benchmark script kept locally, not committed.

I also benchmarked `functional_utils` (`add_params` / `subtract_params` / `divide_by` / `get_neutral`) against vectorized alternatives — no measurable speedup at any size, since list-comprehension overhead is dwarfed by the numpy elementwise op cost. Left untouched.

## Compatibility
This is a wire-format change. Mixed-version client/server clusters (old NPZ on one side, new format on the other) will not interoperate — coordinated rollout required. Worth flagging in release notes.

## Test plan
- [x] `pytest tests/utils/test_serialization.py` — 4 passed (2 new round-trip tests added)
- [x] `pytest tests/parameter` — 2 passed
- [x] Confirmed pre-existing `tests/utils/test_rdd_utils.py` Spark/Py4J failures also fail on master (unrelated)
- [ ] Manual smoke: `BATCH`-frequency parameter-server training run on a real model

🤖 Generated with [Claude Code](https://claude.com/claude-code)