### PR TITLE
fix: deflake parameter-server tests (issue #27)

### DIFF
--- a/elephas/parameter/server.py
+++ b/elephas/parameter/server.py
@@ -7,7 +7,7 @@ from multiprocessing import Process
 from tensorflow.keras.models import Model
 
 from elephas.enums.modes import Mode
-from elephas.utils.sockets import determine_master
+from elephas.utils.sockets import determine_master, wait_until_listening
 from elephas.utils.sockets import recv_bytes, send_bytes
 from elephas.utils.serialization import (
     dict_to_model,
@@ -102,6 +102,8 @@ class HttpServer(BaseParameterServer):
     def start(self):
         self.server.start()
         self.master_url = determine_master(self.port)
+        host = self.master_url.split(":")[0]
+        wait_until_listening(host, self.port)
 
     def stop(self):
         self.server.terminate()
@@ -184,6 +186,8 @@ class SocketServer(BaseParameterServer):
             self.stop()
         self.thread = Thread(target=self.start_server)
         self.thread.start()
+        host = determine_master(port=self.port).split(":")[0]
+        wait_until_listening(host, self.port)
 
     def stop(self):
         self.stop_server()
@@ -192,6 +196,11 @@ class SocketServer(BaseParameterServer):
 
     def start_server(self):
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        # Allow rebinding when a prior test/run left the port in TIME_WAIT,
+        # otherwise back-to-back tests on the same port hit
+        # OSError(EADDRINUSE) and the parent thread eventually times out
+        # waiting on connect with a confusing ConnectionRefused.
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
         master_url = determine_master(port=self.port).split(":")[0]
         host = master_url.split(":")[0]

--- a/elephas/utils/sockets.py
+++ b/elephas/utils/sockets.py
@@ -1,4 +1,6 @@
+import socket
 import struct
+import time
 from socket import gethostbyname, gethostname
 import os
 
@@ -48,19 +50,43 @@ def send_bytes(sock, b: bytes):
 
 
 def recv_bytes(sock) -> bytes:
-    import socket as _s
-
     hdr = b""
     while len(hdr) < 4:
         chunk = sock.recv(4 - len(hdr))
         if not chunk:
-            raise _s.error("socket closed")
+            raise socket.error("socket closed")
         hdr += chunk
     (n,) = struct.unpack("!I", hdr)
     buf = bytearray()
     while len(buf) < n:
         chunk = sock.recv(n - len(buf))
         if not chunk:
-            raise _s.error("socket closed during payload")
+            raise socket.error("socket closed during payload")
         buf.extend(chunk)
     return bytes(buf)
+
+
+def wait_until_listening(host: str, port: int, timeout: float = 30.0) -> None:
+    """Block until a TCP listener accepts on (host, port), or raise TimeoutError.
+
+    Used by parameter-server ``start()`` methods to close the gap between
+    spawning the server (subprocess or thread) and the OS actually performing
+    bind+listen. Without this, the first client request can race ahead and
+    fail with ConnectionRefused. The timeout also surfaces server-startup
+    failures (e.g. bind in TIME_WAIT) that would otherwise hang silently.
+    """
+    deadline = time.monotonic() + timeout
+    last_err: Exception = OSError("no connect attempt was made")
+    while time.monotonic() < deadline:
+        try:
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+                s.settimeout(0.5)
+                s.connect((host, port))
+                return
+        except (ConnectionRefusedError, OSError) as e:
+            last_err = e
+            time.sleep(0.05)
+    raise TimeoutError(
+        f"Server at {host}:{port} did not start listening within {timeout}s "
+        f"(last error: {last_err!r})"
+    )

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -5,8 +5,14 @@ import pytest
 
 @pytest.fixture
 def unused_tcp_port():
-    """Finds and returns an unused TCP port."""
+    """Reserve a TCP port for the test's parameter server.
+
+    SO_REUSEADDR is set BEFORE bind so when the server later rebinds the
+    same port — possibly while the kernel still holds a TIME_WAIT entry from
+    a prior test — the bind succeeds. The original implementation called
+    setsockopt after bind, which has no effect.
+    """
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.bind(("", 0))  # Let OS pick an available port
         s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        s.bind(("", 0))
         return s.getsockname()[1]

--- a/tests/utils/test_sockets.py
+++ b/tests/utils/test_sockets.py
@@ -1,1 +1,67 @@
-# TODO test sockets
+import socket
+import threading
+import time
+
+import pytest
+
+from elephas.utils.sockets import wait_until_listening
+
+
+def _reserve_port() -> int:
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+def _open_listener(port: int) -> socket.socket:
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    sock.bind(("127.0.0.1", port))
+    sock.listen(1)
+    return sock
+
+
+def test_wait_until_listening_returns_when_server_ready():
+    port = _reserve_port()
+    sock = _open_listener(port)
+    try:
+        t0 = time.monotonic()
+        wait_until_listening("127.0.0.1", port, timeout=2)
+        assert time.monotonic() - t0 < 0.5
+    finally:
+        sock.close()
+
+
+def test_wait_until_listening_blocks_until_server_comes_up():
+    port = _reserve_port()
+    delay_seconds = 0.4
+    holder = {}
+
+    def delayed_start():
+        time.sleep(delay_seconds)
+        holder["sock"] = _open_listener(port)
+
+    thread = threading.Thread(target=delayed_start, daemon=True)
+    thread.start()
+    try:
+        t0 = time.monotonic()
+        wait_until_listening("127.0.0.1", port, timeout=3)
+        elapsed = time.monotonic() - t0
+        assert elapsed >= delay_seconds * 0.8
+        assert elapsed < 2
+    finally:
+        thread.join(timeout=1)
+        if "sock" in holder:
+            holder["sock"].close()
+
+
+def test_wait_until_listening_raises_timeout_when_server_never_starts():
+    port = _reserve_port()
+    t0 = time.monotonic()
+    with pytest.raises(TimeoutError, match="did not start listening"):
+        wait_until_listening("127.0.0.1", port, timeout=0.3)
+    # Roughly honors the deadline (allow 1s slack for poll cadence + connect timeout).
+    assert time.monotonic() - t0 < 1.5


### PR DESCRIPTION
Closes #27.

## Summary
Three independent races caused intermittent `ConnectionRefused` in the integration tests:

1. **`unused_tcp_port` fixture set `SO_REUSEADDR` *after* `bind`**, which has no effect. With function-scoped parametrized tests, ports collided with kernel TIME_WAIT entries from prior runs.
2. **`HttpServer.start()` / `SocketServer.start()` returned as soon as the subprocess/thread was spawned.** The first client request could reach the server before its `bind+listen` completed — surfacing as `ConnectionRefused`.
3. **`SocketServer`'s listening socket did not set `SO_REUSEADDR`**, so a bind racing TIME_WAIT silently failed in the worker thread; the parent never noticed and clients hung until they hit a higher-level timeout.

## Fix
- New `utils.sockets.wait_until_listening(host, port, timeout)` helper polls `connect()` until the server accepts or a deadline elapses. Surfaces real bind failures as `TimeoutError` instead of hanging.
- Both `HttpServer.start()` and `SocketServer.start()` call it before returning, so the server is guaranteed to be listening when `start()` exits.
- `SocketServer.start_server` sets `SO_REUSEADDR` before `bind` to tolerate TIME_WAIT.
- `tests/integration/conftest.py::unused_tcp_port` sets `SO_REUSEADDR` before `bind` (was after — a no-op).

## Test plan
- [x] `pytest tests/utils/test_sockets.py` — 3 new tests pass (ready / delayed-up / never-up).
- [x] `pytest tests/utils tests/parameter` — 24 passed; same 2 pre-existing `tests/utils/test_rdd_utils.py` Spark/Py4J failures present on master (unrelated to this change).
- [ ] Full integration run in CI to confirm flake rate drops to zero (intentionally not run locally — Spark startup is heavy and the unit-level test of the wait helper exercises the actual race condition).

## Notes
No API change. The default 30s timeout in `wait_until_listening` is generous for CI cold-starts; servers normally bind within tens of ms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)